### PR TITLE
Add trim code and improve assignment

### DIFF
--- a/Workpackage2/workpackage2.cpp
+++ b/Workpackage2/workpackage2.cpp
@@ -25,8 +25,10 @@
 #include <sstream>
 #include <getopt.h>
 #include <sys/stat.h>
+#include "MIBFClassifier.hpp"
 #include "config.h"
 #include "Common/Options.h"
+#include "bloom_filter.hpp"
 #include "MIBloomFilter.hpp"
 #include "MIBFConstructSupport.hpp"
 //#include "btl_bloomfilter/vendor/stHashIterator.hpp"
@@ -70,7 +72,14 @@ namespace opt {
     std::string seed_preset = "";
     int help = 0;
     int ntcard = 0;
+    int second_pass = 0;
 
+}
+
+bool sort_by_sec(const pair<size_t, size_t> &a,
+              const pair<size_t, size_t> &b)
+{
+    return (a.second > b.second);
 }
 
 static void
@@ -168,17 +177,18 @@ const std::vector<std::string> make_seed_pattern () {
 }
 
 
-size_t calc_num_assigned_tiles (const std::unique_ptr<MIBloomFilter<uint32_t>>& miBF, const std::vector<std::vector<uint64_t>> hashed_values) {
+size_t calc_num_assigned_tiles (const std::unique_ptr<MIBloomFilter<uint32_t>>& miBF, const std::vector<std::vector<uint64_t>> hashed_values, std::vector<uint32_t>& tiles_assigned_id_vec, std::vector<bool>& tiles_assigned_bool_vec) {
 
-    size_t num_tiles = hashed_values.size();
+    
     size_t num_assigned_tiles = 0;
-    std::vector<uint32_t> tiles_assigned_id_vec (num_tiles, 0);
+    size_t num_tiles = hashed_values.size();
+    //std::vector<uint32_t> tiles_assigned_id_vec (num_tiles, 0);
 
 
 #if _OPENMP
 #pragma omp parallel for
 #endif
-    for (size_t i = 1; i < num_tiles - 1; ++i) { // for each tile except first and last tiles. We consider them erroneous and not used in tile assignment.
+    for (size_t i = 0; i < num_tiles; ++i) { // for each tile except first and last tiles. We consider them erroneous and not used in tile assignment.
 
         tsl::robin_map<uint32_t, std::pair<uint32_t, uint32_t>> id_counts; // store counts of ids
 
@@ -240,6 +250,7 @@ size_t calc_num_assigned_tiles (const std::unique_ptr<MIBloomFilter<uint32_t>>& 
 #pragma omp atomic
 #endif
             num_assigned_tiles += 1;
+            tiles_assigned_bool_vec[i] = true;
         }
 
         tiles_assigned_id_vec[i] = curr_id;
@@ -250,16 +261,156 @@ size_t calc_num_assigned_tiles (const std::unique_ptr<MIBloomFilter<uint32_t>>& 
     for (const auto& tiles_assigned_id : tiles_assigned_id_vec) {
         std::cerr << tiles_assigned_id << "\t";
 
+
     }
     std::cerr << std::endl;
 
+    for (const auto& tiles_assigned_bool : tiles_assigned_bool_vec) {
+        std::cerr << tiles_assigned_bool << "\t";
+
+
+    }
+    std::cerr << std::endl;
+    num_assigned_tiles = 0;
+    for (const auto& is_tile_assigned : tiles_assigned_bool_vec) {
+        if (is_tile_assigned) {
+            ++num_assigned_tiles;
+        }
+    }
+
+
+    for (size_t i = 1; i < num_tiles -1; ++i) {
+        if (tiles_assigned_bool_vec[i] == false && tiles_assigned_id_vec[i] > 100) {
+            if ((tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i - 1] && tiles_assigned_bool_vec[i - 1] == true) || (tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i + 1] && tiles_assigned_bool_vec[i + 1] == true)) {
+                tiles_assigned_bool_vec[i] = true;
+            } else if ((tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i - 1] + 1 && tiles_assigned_bool_vec[i - 1] == true) || (tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i + 1] + 1 && tiles_assigned_bool_vec[i + 1] == true)) {
+                tiles_assigned_bool_vec[i] = true;
+            } else if ((tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i - 1] - 1 && tiles_assigned_bool_vec[i - 1] == true) || (tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i + 1] - 1 && tiles_assigned_bool_vec[i + 1] == true)) {
+                tiles_assigned_bool_vec[i] = true;
+            } else if (tiles_assigned_id_vec[i -1] == tiles_assigned_id_vec[i + 1]  && tiles_assigned_bool_vec[i -1] == true &&  tiles_assigned_bool_vec[i + 1] == true) {
+                tiles_assigned_bool_vec[i] = true;
+                tiles_assigned_id_vec[i] = tiles_assigned_id_vec[i -1];
+            }
+        }
+    }
+
+    for (size_t i = num_tiles - 2; i >= 1; --i) {
+        if (tiles_assigned_bool_vec[i] == false  && tiles_assigned_id_vec[i] > 100) {
+            if ((tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i - 1] && tiles_assigned_bool_vec[i - 1] == true) || (tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i + 1] && tiles_assigned_bool_vec[i + 1] == true)) {
+                tiles_assigned_bool_vec[i] = true;
+            } else if ((tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i - 1] + 1 && tiles_assigned_bool_vec[i - 1] == true) || (tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i + 1] + 1 && tiles_assigned_bool_vec[i + 1] == true)) {
+                tiles_assigned_bool_vec[i] = true;
+            } else if ((tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i - 1] - 1 && tiles_assigned_bool_vec[i - 1] == true) || (tiles_assigned_id_vec[i] == tiles_assigned_id_vec[i + 1] - 1 && tiles_assigned_bool_vec[i + 1] == true)) {
+                tiles_assigned_bool_vec[i] = true;
+            } else if (tiles_assigned_id_vec[i -1] == tiles_assigned_id_vec[i + 1]  && tiles_assigned_bool_vec[i -1] == true &&  tiles_assigned_bool_vec[i + 1] == true) {
+                tiles_assigned_bool_vec[i] = true;
+                tiles_assigned_id_vec[i] = tiles_assigned_id_vec[i -1];
+            }
+        }
+    }
+
+    //print which id each tile is assigned to
+    for (const auto& tiles_assigned_id : tiles_assigned_id_vec) {
+        std::cerr << tiles_assigned_id << "\t";
+
+
+    }
+    std::cerr << std::endl;
+
+    for (const auto& tiles_assigned_bool : tiles_assigned_bool_vec) {
+        std::cerr << tiles_assigned_bool << "\t";
+
+
+    }
+    std::cerr << std::endl;
+
+    size_t start_idx = 0;
+    size_t end_idx = 0;
+    //size_t curr_stretch = 0;
+    std::vector<std::pair<size_t, size_t>> coord_vec;
+    for (size_t i = 1; i < num_tiles - 1; ++i){
+        if (tiles_assigned_bool_vec[i] == false && tiles_assigned_bool_vec[i - 1] == true) {
+            start_idx = i;
+        } else if (tiles_assigned_bool_vec[i] == true && tiles_assigned_bool_vec[i - 1] == false) {
+            end_idx = i - 1;
+            coord_vec.push_back(std::make_pair(start_idx, end_idx));
+        }
+    }
+    for (const auto& coords : coord_vec) {
+        const auto& left  = tiles_assigned_id_vec[coords.first - 1];
+        const auto& right  = tiles_assigned_id_vec[coords.second + 1];
+        if (left == right|| left == right + 1 || left == right - 1) {
+            for (auto i = coords.first; i <= coords.second; ++i) {
+                tiles_assigned_bool_vec[i] = true;
+                tiles_assigned_id_vec[i] = left;
+            }
+        }
+
+    }
+
+    //print which id each tile is assigned to
+    for (const auto& tiles_assigned_id : tiles_assigned_id_vec) {
+        std::cerr << tiles_assigned_id << "\t";
+
+
+    }
+    std::cerr << std::endl;
+
+    for (const auto& tiles_assigned_bool : tiles_assigned_bool_vec) {
+        std::cerr << tiles_assigned_bool << "\t";
+
+
+    }
+    std::cerr << std::endl;
+
+
+    for (size_t i = 2; i < num_tiles -2; ++i) {
+        if (tiles_assigned_bool_vec[i] == true && tiles_assigned_id_vec[i] > 100) {
+            if (tiles_assigned_bool_vec[i - 1] == false && tiles_assigned_bool_vec[i + 1] == false) {
+                tiles_assigned_bool_vec[i] = false;
+            }
+        }
+    }
+
+    for (size_t i = num_tiles - 3; i >= 2; --i) {
+        if (tiles_assigned_bool_vec[i] == true && tiles_assigned_id_vec[i] > 100) {
+            if (tiles_assigned_bool_vec[i - 1] == false && tiles_assigned_bool_vec[i + 1] == false) {
+                tiles_assigned_bool_vec[i] = false;
+            }
+        }
+    }
+
+
+    //print which id each tile is assigned to
+    for (const auto& tiles_assigned_id : tiles_assigned_id_vec) {
+        std::cerr << tiles_assigned_id << "\t";
+
+
+    }
+    std::cerr << std::endl;
+
+    for (const auto& tiles_assigned_bool : tiles_assigned_bool_vec) {
+        std::cerr << tiles_assigned_bool << "\t";
+
+
+    }
+    std::cerr << std::endl;
+
+    std::cerr << std::endl;
+    num_assigned_tiles = 0;
+    for (const auto& is_tile_assigned : tiles_assigned_bool_vec) {
+        if (is_tile_assigned) {
+            ++num_assigned_tiles;
+        }
+    }
     return num_assigned_tiles;
 }
 
 
 int main(int argc, char** argv) {
 
-	static const struct option longopts[] = { { "help", no_argument, &opt::help, 1 },
+	static const struct option longopts[] = { { "second_pass", no_argument, &opt::second_pass, 1 },
+                                              { "help", no_argument, &opt::help, 1 },
                                               { "ntcard", no_argument, &opt::ntcard, 1 },
 		                                      { nullptr, 0, nullptr, 0 } };
 
@@ -342,12 +493,14 @@ int main(int argc, char** argv) {
         exit(0);
     }
 
-
+    if (opt::second_pass) {
+        std::cerr << "second_pass" << std::endl;
+    }
 #if _OPENMP
 	omp_set_num_threads(opt::jobs);
 #endif
 
-    size_t min_seq_len = opt::min_length + 2 * opt::tile_length;
+    size_t min_seq_len = opt::min_length;
 
 
     //srand (1); // for testing, change to srand(time(NULL)) for actual code
@@ -482,15 +635,25 @@ int main(int argc, char** argv) {
         for (size_t level = 0; level < opt::levels; ++level) {
             auto& miBF = mibf_vec[level];
             std::cerr << "current level : " << level << std::endl;
+            size_t num_tiles = hashed_values.size();
+            std::vector<uint32_t> tiles_assigned_id_vec (num_tiles, 0);
+            std::vector<bool> tiles_assigned_bool_vec (num_tiles, false);
 
-            const size_t num_assigned_tiles = calc_num_assigned_tiles( miBF, hashed_values);
+            const size_t num_assigned_tiles = calc_num_assigned_tiles( miBF, hashed_values, tiles_assigned_id_vec, tiles_assigned_bool_vec);
             std::cerr << "num assigned tiles: " << num_assigned_tiles << std::endl;
-            size_t num_unassigned_tiles = num_tiles - 2 - num_assigned_tiles;
+            size_t num_unassigned_tiles = num_tiles - num_assigned_tiles;
             std::cerr << "num unassigned tiles: " << num_unassigned_tiles << std::endl;
             
             // assignment logic
             if (num_unassigned_tiles >= opt::unassigned_min && num_assigned_tiles <= opt::assigned_max) {
                 assigned = false;
+            }
+            if (opt::second_pass) {
+                if (num_assigned_tiles == num_tiles) {
+                    assigned = true;
+                } else {
+                    assigned = false;
+                }
             }
 
             if (!assigned) {
@@ -501,16 +664,230 @@ int main(int argc, char** argv) {
 #pragma omp parallel for
 #endif
                 for (size_t i = 0; i < num_tiles; ++i) {
+                    uint32_t curr_ids_inserted = ids_inserted + uint32_t( (i + 1) * opt::tile_length / 10000);
                     const auto& hashed_values_flat_array = hashed_values[i];
-                    miBFCS.insertMIBF(*miBF, hashed_values_flat_array, ids_inserted);//, non_singletons_bf_vec);
+                    miBFCS.insertMIBF(*miBF, hashed_values_flat_array, curr_ids_inserted);//, non_singletons_bf_vec);
                     //miBFCS.insertSaturation(*miBF, Hhashes, ids_inserted); // don't care about saturation atm so skipping for speed
                         //}
-                    }
+                }
+                ids_inserted = ids_inserted + uint32_t(record.seq.size() / 10000);
                 //output read to golden path
                 golden_path_vec[level] << ">" << record.id << '\n' << record.seq << std::endl;
                 break; //breaks the level loop
                 
-            } 
+            } else {
+                if (num_assigned_tiles == num_tiles || opt::second_pass == true) {
+                    std::cerr << "complete assignment" << std::endl;
+                    continue;
+                }
+                /*if (num_tiles < 15) {
+                    continue;
+                }*/
+                /*if (num_unassigned_tiles < 2) {
+                    continue;
+                }*/
+                /*std::unordered_map<size_t, size_t> left_flank;
+                for (int i = 1; i < 11; ++i ){
+                    if (left_flank.contains(left_flank[tiles_assigned_id_vec[i]])) {
+                        ++left_flank[tiles_assigned_id_vec[i]];
+                    } else {
+                        left_flank[tiles_assigned_id_vec[i]] == 1;
+                    }
+                }
+
+                //size_t curr_max_id = 0;
+                //size_t curr_max_hits = 0;
+                std::vector<std::pair<size_t, size_t>> left_flank_vec;
+                for ( const auto &[id, hits]: left_flank ) {
+                    left_flank.push_back(std::make_pair(ids, hits));
+                }                
+                sort(vect.begin(), vect.end(), sort_by_sec);
+                */
+                size_t start_idx = 0;
+                size_t end_idx = 0;
+                ssize_t longest_start_idx = 0;
+                ssize_t longest_end_idx = 0;
+                size_t curr_stretch = 0;
+                size_t longest_stretch = 0;
+                std::cerr << "checkpoint 1" <<std::endl;
+                for (size_t i = 1; i < num_tiles - 1; ++i){
+                    if (tiles_assigned_bool_vec[i] == false && tiles_assigned_bool_vec[i - 1] == true) {
+                        start_idx = i;
+                        curr_stretch = 1;
+                    } else if ((tiles_assigned_bool_vec[i] == false && tiles_assigned_bool_vec[i] == tiles_assigned_bool_vec[i-1]) && (i + 1 != num_tiles - 1)) {
+                        ++curr_stretch;
+                    } else if (tiles_assigned_bool_vec[i] == true && tiles_assigned_bool_vec[i] != tiles_assigned_bool_vec[i-1]) {
+                        end_idx = i - 1;
+                        if (longest_stretch < curr_stretch) {
+                            longest_stretch = curr_stretch;
+                            longest_start_idx = (ssize_t)start_idx;
+                            longest_end_idx = (ssize_t)end_idx;
+                        }                       
+                    } else if (i + 1 == num_tiles - 1 && end_idx < start_idx) {
+                        end_idx = i;
+                        ++curr_stretch;
+                        if (longest_stretch < curr_stretch) {
+                            longest_stretch = curr_stretch;
+                            longest_start_idx = (ssize_t)start_idx;
+                            longest_end_idx = (ssize_t)end_idx;
+                        }
+                    }
+                }
+
+                bool good_flank = false;
+                size_t trim_start_idx = longest_start_idx - 1;
+                size_t trim_end_idx = longest_end_idx + 1;
+
+                if (num_tiles < 15) {
+                    bool good_right_flank = false;
+                    bool good_left_flank = false;
+                    std::unordered_map<size_t, size_t> left_flank;
+                    for (ssize_t i = longest_start_idx - 1; i >= 1; --i ){
+                        if (left_flank.contains(tiles_assigned_id_vec[i])) {
+                            ++left_flank[tiles_assigned_id_vec[i]];
+                        } else {
+                            left_flank[tiles_assigned_id_vec[i]] = 1;
+                        }
+                    }
+                    std::cerr << "checkpoint 2.1" <<std::endl;
+                    std::vector<std::pair<size_t, size_t>> left_flank_vec;
+                    for (  const auto &myPair: left_flank ) {
+                        left_flank_vec.push_back(std::make_pair(myPair.first, myPair.second));
+                    }
+                    std::cerr << "checkpoint 2.2" <<std::endl;                
+                    sort(left_flank_vec.begin(), left_flank_vec.end(), sort_by_sec);
+                    std::cerr << "checkpoint 2.3" <<std::endl;
+                    std::cerr << left_flank_vec.size() <<std::endl;
+                    if (left_flank_vec.size() != 0) {
+                        if (left_flank_vec[0].second >= 2) {
+                            trim_start_idx = longest_start_idx - 2;
+                            good_left_flank = true;
+                        } else if ( left_flank_vec.size() >= 2 && (left_flank_vec[0].second + left_flank_vec[1].second> 3 && (left_flank_vec[0].first - left_flank_vec[1].first == 1 || left_flank_vec[1].first - left_flank_vec[0].first == 1))) {
+                            trim_start_idx = longest_start_idx - 2;
+                            good_left_flank = true;       
+
+                        }
+                    }
+                    std::unordered_map<size_t, size_t> right_flank;
+                    for (ssize_t i = longest_end_idx + 1; i < (ssize_t)num_tiles - 1; ++i ){
+                        if (right_flank.contains(tiles_assigned_id_vec[i])) {
+                            ++right_flank[tiles_assigned_id_vec[i]];
+                        } else {
+                            right_flank[tiles_assigned_id_vec[i]] = 1;
+                        }
+                    }
+                    std::vector<std::pair<size_t, size_t>> right_flank_vec;
+                    for ( const auto &myPair :  right_flank ) {
+                        right_flank_vec.push_back(std::make_pair(myPair.first, myPair.second));
+                    }                
+                    sort(right_flank_vec.begin(), right_flank_vec.end(), sort_by_sec);
+                    if (right_flank_vec.size() != 0) {
+                        if (right_flank_vec[0].second >= 2) {
+                            trim_end_idx = longest_end_idx + 2;
+                            good_right_flank = true;
+                        } else if ( right_flank_vec.size() >= 2 && (right_flank_vec[0].second + right_flank_vec[1].second> 3 && (right_flank_vec[0].first - right_flank_vec[1].first == 1 || right_flank_vec[1].first - right_flank_vec[0].first == 1))) {
+                            trim_end_idx = longest_end_idx + 2;
+                            good_right_flank = true;    
+
+                        }
+                    }
+                    if (good_left_flank && good_right_flank) {
+                        good_flank = true;
+                    }
+                } else {
+                    std::cerr << "checkpoint 2" <<std::endl;
+                    //bool valid = true;
+
+                    if (longest_start_idx - 5 >= 1 ) {
+                        std::unordered_map<size_t, size_t> left_flank;
+                        for (ssize_t i = longest_start_idx - 5; i < longest_start_idx; ++i ){
+                            if (left_flank.contains(tiles_assigned_id_vec[i])) {
+                                ++left_flank[tiles_assigned_id_vec[i]];
+                            } else {
+                                left_flank[tiles_assigned_id_vec[i]] = 1;
+                            }
+                        }
+                        std::cerr << "checkpoint 2.1" <<std::endl;
+                        std::vector<std::pair<size_t, size_t>> left_flank_vec;
+                        for (  const auto &myPair: left_flank ) {
+                            left_flank_vec.push_back(std::make_pair(myPair.first, myPair.second));
+                        }
+                        std::cerr << "checkpoint 2.2" <<std::endl;                
+                        sort(left_flank_vec.begin(), left_flank_vec.end(), sort_by_sec);
+                        std::cerr << "checkpoint 2.3" <<std::endl;
+                        std::cerr << left_flank_vec.size() <<std::endl;
+                        if (left_flank_vec[0].second >= 2) {
+                            trim_start_idx = longest_start_idx - 2;
+                            good_flank = true;
+                        } else if (left_flank_vec[0].second + left_flank_vec[1].second> 3 && (left_flank_vec[0].first - left_flank_vec[1].first == 1 || left_flank_vec[1].first - left_flank_vec[0].first == 1)) {
+                            trim_start_idx = longest_start_idx - 2;
+                            good_flank = true;       
+
+                        }  
+                        std::cerr << "checkpoint 2.4" <<std::endl;
+                    } else {
+                        trim_start_idx = 0;
+                    }
+                    std::cerr << "checkpoint 3" <<std::endl;
+
+                    if (longest_end_idx + 5 < (ssize_t)num_tiles - 1 ) {
+                        std::unordered_map<size_t, size_t> right_flank;
+                        for (ssize_t i = longest_end_idx + 5; i > longest_end_idx; --i ){
+                            if (right_flank.contains(tiles_assigned_id_vec[i])) {
+                                ++right_flank[tiles_assigned_id_vec[i]];
+                            } else {
+                                right_flank[tiles_assigned_id_vec[i]] = 1;
+                            }
+                        }
+                        std::vector<std::pair<size_t, size_t>> right_flank_vec;
+                        for ( const auto &myPair :  right_flank ) {
+                            right_flank_vec.push_back(std::make_pair(myPair.first, myPair.second));
+                        }                
+                        sort(right_flank_vec.begin(), right_flank_vec.end(), sort_by_sec);
+                        if (right_flank_vec[0].second >= 2) {
+                            trim_end_idx = longest_end_idx + 2;
+                            good_flank = true;
+                        } else if (right_flank_vec[0].second + right_flank_vec[1].second> 3 && (right_flank_vec[0].first - right_flank_vec[1].first == 1 || right_flank_vec[1].first - right_flank_vec[0].first == 1)) {
+                        trim_end_idx = longest_end_idx + 2;
+                        good_flank = true;    
+
+                        }
+
+                    } else {
+                        trim_end_idx = (ssize_t)num_tiles - 1;
+                    }
+                }
+                std::cerr << "checkpoint 4" <<std::endl;
+                if (good_flank) {
+                    assigned = false;
+                    std::cerr << "trimmed" << std::endl;
+                    ++ids_inserted;
+
+#if _OPENMP
+#pragma omp parallel for
+#endif
+                    for (size_t i = trim_start_idx; i <= trim_end_idx; ++i) {
+                        uint32_t curr_ids_inserted = ids_inserted + uint32_t( (i - trim_start_idx + 1) * opt::tile_length / 10000);
+                        const auto& hashed_values_flat_array = hashed_values[i];
+                        miBFCS.insertMIBF(*miBF, hashed_values_flat_array, curr_ids_inserted);//, non_singletons_bf_vec);
+                        //miBFCS.insertSaturation(*miBF, Hhashes, ids_inserted); // don't care about saturation atm so skipping for speed
+                            //}
+                    }
+                    ids_inserted = ids_inserted + uint32_t((trim_end_idx - trim_start_idx) * 1000 / 10000);
+                    //output read to golden path
+                    if (trim_end_idx == num_tiles -1) {
+                        golden_path_vec[level] << ">trimmed" << record.id << '\n' << record.seq.substr(trim_start_idx * 1000,std::string::npos) << std::endl;
+                    } else {
+                        golden_path_vec[level] << ">trimmed" << record.id << '\n' << record.seq.substr(trim_start_idx * 1000, (trim_end_idx - trim_start_idx + 1) * 1000) << std::endl;
+                    }
+                    
+
+                    break; //breaks the level loop
+                    
+                }
+
+            }
+
         }
         if (assigned) {
             std::cerr << "assigned" << std::endl;


### PR DESCRIPTION
This PR contains code to rescue unassigned tiles found in discarded reads. Discarded reads are reads that do not fit -u and -a criteria. These reads will undergo a second round of processing to determine if they have viable contiguous sections of unassigned regions. If there are, workpackage2 will attempt to extract it along with 1 additional left and right tiles in an attempt to maximize genome coverage. This PR also contains logic to improve assignment by using association. Adjacent tiles must have the same id, id - 1, or id +1. Using this logic, we can correct assignment due to random hits.