### PR TITLE
Reuse MIBF instead of creating new MIBF

### DIFF
--- a/goldrush_path/MIBFConstructSupport.hpp
+++ b/goldrush_path/MIBFConstructSupport.hpp
@@ -180,7 +180,7 @@ public:
     return miBF;
   }
 
-  void resetBF()
+  void reset_counts()
   {
     memset(&m_counts[0], 0, m_counts.size() * sizeof m_counts[0]);
   }

--- a/goldrush_path/MIBloomFilter.hpp
+++ b/goldrush_path/MIBloomFilter.hpp
@@ -637,7 +637,7 @@ public:
     return satProp;
   }
 
-  void resetBF() {
+  void reset_ID_vector() {
     memset(&m_data[0], 0, m_data.size() * sizeof m_data[0]);
   }
 

--- a/goldrush_path/goldrush_path.cpp
+++ b/goldrush_path/goldrush_path.cpp
@@ -67,8 +67,8 @@ silver_path_check(
       exit(0);
     }
     inserted_bases = 0;
-    miBFCS.resetBF();
-    mibf_vec[0]->resetBF();
+    miBFCS.reset_counts();
+    mibf_vec[0]->reset_ID_vector();
     golden_path_vec.pop_back();
     golden_path_vec.emplace_back(std::ofstream(
       opt::prefix_file + "_" + std::to_string(curr_path) + ".fq"));


### PR DESCRIPTION
This PR fixes a RAM bug we were seeing where with more paths, the amount of RAM goldrush-path use is increased per path. This PR fixes the bug by reusing the MIBF by setting the values in the ID array to 0. In addition, we also have to set the counts to 0 for reservoir  sampling.