### PR TITLE
Set ulimit before running each step of GoldRush

### DIFF
--- a/bin/goldrush
+++ b/bin/goldrush
@@ -49,6 +49,9 @@ Please check the supplied `reads` parameter in your goldrush command, and ensure
 For example, if your reads file is `my_reads.fq`, specify `reads=my_reads`
 endef
 
+# Wrapper script for commands that require an increased stack size limit
+stack=abyss-stack-size 256000
+
 # Default parameters GoldRush-Path
 k=22
 w=16
@@ -213,21 +216,21 @@ endif
 goldrush-path: $(p2).fa check-G check-reads clean
 
 $(p2).fa: $(p1)_all.fq
-	$(time) goldrush-path  -k $(k) -w $(w) -t $(tile) -u $(u) -a $(a) -o $(o) -p $(p2) -i $< -h $(h) -j $(t) -P $(P) -d $(d) -x$(x) -s $(s) -g $(G) -b $(b)  -m 0
+	$(time) $(stack) goldrush-path  -k $(k) -w $(w) -t $(tile) -u $(u) -a $(a) -o $(o) -p $(p2) -i $< -h $(h) -j $(t) -P $(P) -d $(d) -x$(x) -s $(s) -g $(G) -b $(b)  -m 0
 	echo "Done GoldRush-Path! Golden path can be found in: $@"
 
 $(p1)_all.fq: $(p1)_$(M).fq
 	cat $(p1)_*.fq > $@
 
 $(p1)_$(M).fq: $(long_reads)
-	$(time) goldrush-path  -k $(k) -w $(w) -t $(tile) -u $(u) -a $(a) -o $(o) -p $(p1) -i $<  -h $(h) -j $(t) -x$(x) -P $(P) -d $(d) -s $(s) -g $(G) -b $(b) -r $(r) --silver_path -M $(M) -m $(m)
+	$(time) $(stack) goldrush-path  -k $(k) -w $(w) -t $(tile) -u $(u) -a $(a) -o $(o) -p $(p1) -i $<  -h $(h) -j $(t) -x$(x) -P $(P) -d $(d) -s $(s) -g $(G) -b $(b) -r $(r) --silver_path -M $(M) -m $(m)
 
 %.racon-polished.fa: %.fa.$(long_reads).sam %.fa
-	$(time) racon -u -t$(t) $(long_reads) $^ > $@
+	$(time) $(stack) racon -u -t$(t) $(long_reads) $^ > $@
 	echo "Done GoldRush-Path + $(polisher_logs)! $(polisher_logs) polished golden path can be found in: $@"
 
 %.goldrush-edit-polished.fa: %.fa $(long_reads)
-	$(time) goldrush-edit $(goldrush_edit_opts) -t$(t) -m$(shared_mem) $< $(long_reads) $@
+	$(time) $(stack) goldrush-edit $(goldrush_edit_opts) -t$(t) -m$(shared_mem) $< $(long_reads) $@
 	echo "Done GoldRush-Path + $(polisher_logs)! $(polisher_logs) polished golden path can be found in: $@"
 
 # Run racon
@@ -236,7 +239,7 @@ racon: $(p2).racon-polished.fa check-G check-reads
 goldrush-edit: $(p2).goldrush-edit-polished.fa check-G check-reads
 
 $(p2).fa.$(long_reads).sam: $(p2).fa $(long_reads)
-	$(time) minimap2 -t $(t) -a -x map-ont  $< $(long_reads) > $@
+	$(time) $(stack) minimap2 -t $(t) -a -x map-ont  $< $(long_reads) > $@
 
 
 # Run tigmint after GoldRush-Path
@@ -247,15 +250,15 @@ $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa: $(p2).$(polished_inf
 	echo "Done GoldRush-Path + $(polisher_logs) + Tigmint-long! Post-Tigmint-long golden path can be found in: $@"
 
 %.$(polished_infix).cut$(cut).tigmint.fa: %.$(polished_infix).fa $(long_reads)
-	$(time) tigmint-make tigmint-long draft=$(p2).$(polished_infix) reads=$(reads) cut=$(cut) t=$t G=$G span=$(span) dist=$(dist)
+	$(time) $(stack) tigmint-make tigmint-long draft=$(p2).$(polished_infix) reads=$(reads) cut=$(cut) t=$t G=$G span=$(span) dist=$(dist)
 
 # Run ntLink rounds after tigmint
 ntLink_all_rounds: $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa.k$(k_ntLink).w$(w_ntLink).z$z.ntLink.gap_fill.$(rounds)rounds.fa check-G check-reads
 
 %.fa.k$(k_ntLink).w$(w_ntLink).z$z.ntLink.gap_fill.$(rounds)rounds.fa: %.fa $(long_reads)
-	$(time) ntLink_rounds run_rounds_gaps target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z rounds=$(rounds) reads=$(long_reads)
+	$(time) $(stack) ntLink_rounds run_rounds_gaps target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z rounds=$(rounds) reads=$(long_reads)
 ifneq ($(dev), True)
-	ntLink_rounds clean target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z rounds=$(rounds) reads=$(long_reads)
+	$(time) $(stack) ntLink_rounds clean target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z rounds=$(rounds) reads=$(long_reads)
 endif
 
 ntLink_softlink: $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa.k$(k_ntLink).w$(w_ntLink).ntLink-$(rounds)rounds.fa check-G check-reads

--- a/bin/goldrush-stack-size
+++ b/bin/goldrush-stack-size
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Taken from https://github.com/bcgsc/abyss/blob/master/bin/abyss-stack-size
+
+if [ $# -lt 2 ]; then
+	echo "Usage: $(basename $0) <STACK_SIZE> <COMMAND>" >&2
+	echo "Run COMMAND in a shell with a maximum stack size of" >&2
+	echo "at least STACK_SIZE in kilobytes." >&2
+	exit 1
+fi
+min_stack=$1; shift
+
+# Note: A max stack size of "unlimited" may not actually
+# be unlimited. For example, on Linux, using "unlimited"
+# results in a max stack size of 2 MB, which
+# is less than the default max stack size of 8 MB.
+
+stack=$(ulimit -s)
+if [ "$stack" = "unlimited" ] || [ "$stack" -lt "$min_stack" ]; then
+	ulimit -s $min_stack
+fi
+stack=$(ulimit -s)
+
+echo "Running with max stack size of $stack KB: $*" >&2
+exec /bin/sh -c "$*"


### PR DESCRIPTION
This PR sets the ulimit for each step. Based on the `abyss-pe` make file, this change should not persist after running GoldRush.