### PR TITLE
Set ulimit to max using a bash script

### DIFF
--- a/bin/goldrush
+++ b/bin/goldrush
@@ -18,6 +18,10 @@ shared_mem=/dev/shm
 polish_k=32
 polish_w=100
 
+# Set max number of user processes
+max_processes=256000
+set_ulimit=ulimit -u $(max_processes)
+
 ifeq ($(polisher), goldrush-edit)
 polisher_logs=GoldRush-Edit
 else
@@ -227,7 +231,7 @@ $(p1)_$(M).fq: $(long_reads)
 	echo "Done GoldRush-Path + $(polisher_logs)! $(polisher_logs) polished golden path can be found in: $@"
 
 %.goldrush-edit-polished.fa: %.fa $(long_reads)
-	$(time) goldrush-edit $(goldrush_edit_opts) -t$(t) -m$(shared_mem) $< $(long_reads) $@
+	$(set_ulimit); $(time) goldrush-edit $(goldrush_edit_opts) -t$(t) -m$(shared_mem) $< $(long_reads) $@
 	echo "Done GoldRush-Path + $(polisher_logs)! $(polisher_logs) polished golden path can be found in: $@"
 
 # Run racon

--- a/bin/goldrush
+++ b/bin/goldrush
@@ -19,8 +19,7 @@ polish_k=32
 polish_w=100
 
 # Set max number of user processes
-max_processes=$(shell ulimit -Hu)
-set_ulimit=ulimit -u $(max_processes)
+set_ulimit=goldrush-ulimit
 
 ifeq ($(polisher), goldrush-edit)
 polisher_logs=GoldRush-Edit
@@ -231,7 +230,7 @@ $(p1)_$(M).fq: $(long_reads)
 	echo "Done GoldRush-Path + $(polisher_logs)! $(polisher_logs) polished golden path can be found in: $@"
 
 %.goldrush-edit-polished.fa: %.fa $(long_reads)
-	$(set_ulimit); $(time) goldrush-edit $(goldrush_edit_opts) -t$(t) -m$(shared_mem) $< $(long_reads) $@
+	$(time) $(set_ulimit) goldrush-edit $(goldrush_edit_opts) -t$(t) -m$(shared_mem) $< $(long_reads) $@
 	echo "Done GoldRush-Path + $(polisher_logs)! $(polisher_logs) polished golden path can be found in: $@"
 
 # Run racon

--- a/bin/goldrush
+++ b/bin/goldrush
@@ -19,7 +19,7 @@ polish_k=32
 polish_w=100
 
 # Set max number of user processes
-max_processes=256000
+max_processes=$(shell ulimit -Hu)
 set_ulimit=ulimit -u $(max_processes)
 
 ifeq ($(polisher), goldrush-edit)

--- a/bin/goldrush-ulimit
+++ b/bin/goldrush-ulimit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ $# -lt 1 ]; then
 	echo "Usage: $(basename $0) <COMMAND>" >&2

--- a/bin/goldrush-ulimit
+++ b/bin/goldrush-ulimit
@@ -12,6 +12,6 @@ max_processes=$(ulimit -Hu)
 ulimit -Su ${max_processes}
 max_processes=$(ulimit -u)
 
-echo "Running with ${stack} max processes: $*" >&2
+echo "Running with ${max_processes} max processes: $*" >&2
 exec /bin/sh -c "$*"
 

--- a/bin/goldrush-ulimit
+++ b/bin/goldrush-ulimit
@@ -9,7 +9,7 @@ fi
 set -eux -o pipefail
 
 max_processes=$(ulimit -Hu)
-ulimit -u ${max_processes}
+ulimit -Su ${max_processes}
 max_processes=$(ulimit -u)
 
 echo "Running with ${stack} max processes: $*" >&2

--- a/bin/goldrush-ulimit
+++ b/bin/goldrush-ulimit
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ $# -lt 1 ]; then
+	echo "Usage: $(basename $0) <COMMAND>" >&2
+	echo "Run COMMAND in a shell with max available max processes" >&2
+	exit 1
+fi
+
+set -eux -o pipefail
+
+max_processes=$(ulimit -Hu)
+ulimit -u ${max_processes}
+max_processes=$(ulimit -u)
+
+echo "Running with ${stack} max processes: $*" >&2
+exec /bin/sh -c "$*"
+

--- a/bin/goldrush-ulimit
+++ b/bin/goldrush-ulimit
@@ -6,8 +6,6 @@ if [ $# -lt 1 ]; then
 	exit 1
 fi
 
-set -eux -o pipefail
-
 max_processes=$(ulimit -Hu)
 ulimit -Su ${max_processes}
 max_processes=$(ulimit -u)

--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,1 +1,2 @@
-install_data('goldrush', install_dir : 'bin')
+scripts = ['goldrush', 'goldrush-ulimit']
+install_data(scripts, install_dir : 'bin')


### PR DESCRIPTION
GoldRush-Edit creates a lot of process, sometimes more than the default maximum number a user can create. This PR adds a script that is called before GoldRush-Edit that increases the maximum number of processes to the maximum of the system.

The script was first tested by using a conda environment of GoldRush 1.0.2 with `ulimit -Su 100`. Once I observed that it failed during the GoldRush-Edit, I compiled the code on this branch and ran it on the same directory. GoldRush-Edit completed with no problem.