### PR TITLE
Add G to ntLink_rounds command to avoid parameter name collision

### DIFF
--- a/bin/goldrush
+++ b/bin/goldrush
@@ -288,9 +288,9 @@ $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa: $(p2).$(polished_inf
 ntLink_all_rounds: $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa.k$(k_ntLink).w$(w_ntLink).z$z.ntLink.gap_fill.$(rounds)rounds.fa check-G check-reads
 
 %.fa.k$(k_ntLink).w$(w_ntLink).z$z.ntLink.gap_fill.$(rounds)rounds.fa: %.fa $(long_reads)
-	$(time) ntLink_rounds run_rounds_gaps target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads)
+	$(time) ntLink_rounds run_rounds_gaps target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads) G=-1
 ifneq ($(dev), True)
-	ntLink_rounds clean target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads)
+	ntLink_rounds clean target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads) G=-1
 endif
 
 ntLink_softlink: $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa.k$(k_ntLink).w$(w_ntLink).ntLink-$(rounds)rounds.fa check-G check-reads

--- a/bin/goldrush
+++ b/bin/goldrush
@@ -288,9 +288,9 @@ $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa: $(p2).$(polished_inf
 ntLink_all_rounds: $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa.k$(k_ntLink).w$(w_ntLink).z$z.ntLink.gap_fill.$(rounds)rounds.fa check-G check-reads
 
 %.fa.k$(k_ntLink).w$(w_ntLink).z$z.ntLink.gap_fill.$(rounds)rounds.fa: %.fa $(long_reads)
-	$(time) ntLink_rounds run_rounds_gaps target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads) G=-1
+	$(time) ntLink_rounds run_rounds_gaps target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads) G=-1 a=1
 ifneq ($(dev), True)
-	ntLink_rounds clean target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads) G=-1
+	ntLink_rounds clean target=$< t=$t k=$(k_ntLink) w=$(w_ntLink) z=$z soft_mask=$(soft_mask) rounds=$(rounds) reads=$(long_reads) G=-1 a=1
 endif
 
 ntLink_softlink: $(p2).$(polished_infix).span$(span).dist$(dist).tigmint.fa.k$(k_ntLink).w$(w_ntLink).ntLink-$(rounds)rounds.fa check-G check-reads


### PR DESCRIPTION
* GoldRush has a `G` parameter, and ntLink does now too for `max_gap`, leading to a parameter name conflict
  * This PR fixes that
  * Also pin `a` - collision, but same defaults in ntLink and GoldRush
* Thanks @emilyyzhangg for finding this bug!