### PR TITLE
Pin minimap2 version in linux CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
   - script: |
       source activate goldrush_CI
       conda install --yes -c conda-forge mamba=1.5.10 python=3.10 
-      mamba install --yes -c conda-forge -c bioconda compilers meson gperftools sdsl-lite boost-cpp sparsehash btllib libdivsufsort minimap2 tigmint ntlink miller snakemake intervaltree  
+      mamba install --yes -c conda-forge -c bioconda compilers meson gperftools sdsl-lite boost-cpp sparsehash btllib libdivsufsort 'minimap2>=2.21' tigmint ntlink miller snakemake intervaltree  
     displayName: Install dependencies
   - script: |
       source activate goldrush_CI


### PR DESCRIPTION
* Unsure when this started happening, but I noticed that the ubuntu CI was installing a very old version of minimap2 (2.1.1), leading to an undetected error in the tigmint-long step of the CI
```
[M::mm_idx_stat::0.077*1.03] distinct minimizers: 194597 (94.91% are singletons); average occurrences: 1.057; average spacing: 5.351
Traceback (most recent call last):
  File "/usr/share/miniconda/envs/goldrush_CI/bin/share/tigmint-1.2.10-3/bin/tigmint_molecule_paf.py", line 141, in <module>
    main()
  File "/usr/share/miniconda/envs/goldrush_CI/bin/share/tigmint-1.2.10-3/bin/tigmint_molecule_paf.py", line 138, in main
    MolecIdentifierPaf().run()
  File "/usr/share/miniconda/envs/goldrush_CI/bin/share/tigmint-1.2.10-3/bin/tigmint_molecule_paf.py", line 85, in run
    paf_entry[18]
IndexError: list index out of range
/usr/share/miniconda/envs/goldrush_CI/bin/share/tigmint-1.2.10-3/bin/tigmint-cut -p4 -w1000 -n2 -t0 -m3000 -o goldrush_test_golden_path.goldpolish-polished.test_reads.cut250.molecule.size2000.dist500.trim0.window1000.span2.breaktigs.fa goldrush_test_golden_path.goldpolish-polished.fa goldrush_test_golden_path.goldpolish-polished.test_reads.cut250.molecule.size2000.dist500.bed
Started at: 2024-11-01 19:10:59.382650
Reading contig lengths...
Finding breakpoints...
Attempted corrections: 0
```
* Just pin the version to avoid that here - I will also pin that in the GoldRush conda recipe to be safe